### PR TITLE
fixed a corner case with long transcription blocks

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -118,8 +118,11 @@ for x in json_data["results"]:
                             custom_tran = ""
                             tran_start = 0
                             tran_end = 0
-                sub_id += 1
-                tran_list.append([sub_id,custom_tran,tran_start,tran_end])
+                # make sure the custom_tran is not empty, which could happen in a long_tran case where
+                # we reach the max_chars on the last word of the transcript
+                if tran_start != 0 :
+                    sub_id += 1
+                    tran_list.append([sub_id,custom_tran,tran_start,tran_end])
             except:
                 print 'ERROR: Cannot find timestamps in JSON. Please ensure word timestamps are enabled in Watson.'
                 quit()


### PR DESCRIPTION
found a corner case while using this tool where a long transcription
block could have just the right number of words / chars so that when the
custom_tran > max_chars, and we complete the subtitle and add it to
tran_list, that is the last word in "timestamps" this causes us to add
an empty subtitle to tran_list which then segfaults down in
format_time() because the start and end time are now 0.